### PR TITLE
Rewrite ratio of means spec

### DIFF
--- a/editing_and_imputation/imputation/ratio_of_means.md
+++ b/editing_and_imputation/imputation/ratio_of_means.md
@@ -281,6 +281,7 @@ v((c)) = {
 ```
 
 Based on the above definition, we can define the types of imputation as:
+
 * `v_(forward)((c)) = v((c)) "where" p_(predictive) = p_(target) - 1` and
     `p_(sequence)` is in ascending order
 * `v_(backward)((c)) = v((c)) "where" p_(predictive) = p_(target) + 1` and


### PR DESCRIPTION
- Update ratio_of_means.md
- Update ratio_of_means.md
- Update ratio_of_means.md
- Update ratio_of_means.md
- Markdown checker
- More Markdown tidy
- Maybe happy now?
- Alias Link
- Update ratio_of_means.md
- Update ratio_of_means.md
- Update ratio_of_means.md
- Update ratio_of_means.md
- Update ratio_of_means.md
- Update ratio_of_means.md
- Update ratio_of_means.md
- Update ratio_of_means.md
- Update ratio_of_means.md
- Undo Tests
- Update ratio_of_means.md
- Update ratio_of_means.md
- Update ratio_of_means.md
- Tried to make statement clearer.
- Partial alteration of language and other changes
- Alter definition of predictive period and move link definition
- Link calculation and other tidy up
- Linting
- Linting
- Responder filtering, clean up terminology around matched pairs and other cleanup
- Construction and a note on grouping
- Add average imputation and more specifics on different imputation types
- Remove special cases, exceptions and unimplemented features sections and add specific section for back data
- Update ratio_of_means.md
- Lint
- Temp Addition For Discussion Of Layout
- Continued rewriting
- More maths rewriting
- Remove average imputation
- Imputation maths and rewording
- Space out maths in ratio off means spec
- Update ratio_of_means.md
- Lint Plus Technical Changes
- move input and output specification around and add a note on field name interpretation
- Unnessaccary 6
- Tidy
- Put input and output sections under an overall section and rename appropriately
- Reorder and remove sections
- Alter maths, correct notation and add default links
- Clarify that the calculations only calculate a target variable
